### PR TITLE
[backport] numpy.typing ArrayLike not available,

### DIFF
--- a/src/bpm_data_combiner/bl/statistics.py
+++ b/src/bpm_data_combiner/bl/statistics.py
@@ -1,11 +1,13 @@
 import numpy as np
 from numpy import ma
-from numpy.typing import ArrayLike
+# which numpy version supports that ?
+# from numpy.typing import ArrayLike
 
 from ..data_model.bpm_data_accumulation import BPMDataAccumulationForPlane, BPMDataAccumulation
 from ..data_model.bpm_data_collection import BPMDataCollectionStatsPlane, BPMDataCollectionStats
 
-def compute_weights_scaled(values: ArrayLike, *, n_readings: int) -> ArrayLike:
+def compute_weights_scaled(values#: ArrayLike,
+                           ,*, n_readings: int): # -> ArrayLike:
     """Compute weights taking number of readings into account
 
     Currently unused


### PR DESCRIPTION
removed until necessary numpy version identified

